### PR TITLE
GPU utilization display

### DIFF
--- a/docker/app/settings.yaml
+++ b/docker/app/settings.yaml
@@ -19,7 +19,7 @@ postgres:
   host: 'database'
 
 aws:
-  region: 'us-east-1'
+  region: 'us-west-2'
   ebs_optimized: False
   subnets:
     - 'subnet-1fb84b55'

--- a/nebula/routes/servers.py
+++ b/nebula/routes/servers.py
@@ -204,7 +204,6 @@ def profile_ami(profile_id):
 def get_server_information(server):
     hourly_price = aws.get_instance_description(server.instance_type)['price']
     tags = aws.get_tags_from_aws_object(server)
-    #print(tags)
     return {
         'ami': server.image_id,
         'launch': server.launch_time,

--- a/nebula/routes/servers.py
+++ b/nebula/routes/servers.py
@@ -204,6 +204,7 @@ def profile_ami(profile_id):
 def get_server_information(server):
     hourly_price = aws.get_instance_description(server.instance_type)['price']
     tags = aws.get_tags_from_aws_object(server)
+    #print(tags)
     return {
         'ami': server.image_id,
         'launch': server.launch_time,
@@ -220,5 +221,6 @@ def get_server_information(server):
         'shutdown': tags.get('Shutdown', False),
         'gpushutdown': tags.get('GPU_Shutdown', False),
         'name': tags.get('Name', ''),
+        'gpu_utilization': tags.get('GPU_Utilization', -1),
         'state': server.state['Name']
     }

--- a/nebula/static/js/app.js
+++ b/nebula/static/js/app.js
@@ -545,7 +545,7 @@ function getNewRow (server, admin = false) {
 }
 
 function getInstanceInfoTable (instanceData) {
-  let infotable = `<table id='instance_info_${instanceData['instance_id']}' class='unstriped'>
+  let infotable_html = `<table id='instance_info_${instanceData['instance_id']}' class='unstriped'>
     <tr><td>Name:</td><td>${instanceData['name']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['name']}" title="Copy '${instanceData['name']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
     <tr><td>Hourly Price:</td><td>$${instanceData['price']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['price']}" title="Copy '${instanceData['price']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
     <tr><td>Instance ID:</td><td>${instanceData['instance_id']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['instance_id']}" title="Copy '${instanceData['instance_id']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
@@ -554,18 +554,10 @@ function getInstanceInfoTable (instanceData) {
     `
   if(instanceData['gpu_utilization']!=-1){
     //gpu utilization is defined
-    infotable = infotable + `<tr><td>GPU Utilization:</td><td>${instanceData['gpu_utilization']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['gpu_utilization']}" title="Copy '${instanceData['gpu_utilization']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>`
+    infotable_html = infotable + `<tr><td>GPU Utilization:</td><td>${instanceData['gpu_utilization']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['gpu_utilization']}" title="Copy '${instanceData['gpu_utilization']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>`
   }
-  infotable = infotable + `</table>`
-  return infotable
-  // return `<table id='instance_info_${instanceData['instance_id']}' class='unstriped'>
-  //   <tr><td>Name:</td><td>${instanceData['name']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['name']}" title="Copy '${instanceData['name']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
-  //   <tr><td>Hourly Price:</td><td>$${instanceData['price']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['price']}" title="Copy '${instanceData['price']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
-  //   <tr><td>Instance ID:</td><td>${instanceData['instance_id']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['instance_id']}" title="Copy '${instanceData['instance_id']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
-  //   <tr><td>AMI:</td><td>${instanceData['ami']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['ami']}" title="Copy '${instanceData['ami']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
-  //   <tr><td>Profile:</td><td>${instanceData['profile']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['profile']}" title="Copy '${instanceData['profile']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
-  //   <tr><td>GPU Utilization:</td><td>${instanceData['gpu_utilization']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['gpu_utilization']}" title="Copy '${instanceData['gpu_utilization']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
-  // </table>`
+  infotable_html = infotable + `</table>`
+  return infotable_html
 }
 
 function getControlPanel (server) {

--- a/nebula/static/js/app.js
+++ b/nebula/static/js/app.js
@@ -545,13 +545,27 @@ function getNewRow (server, admin = false) {
 }
 
 function getInstanceInfoTable (instanceData) {
-  return `<table id='instance_info_${instanceData['instance_id']}' class='unstriped'>
+  let infotable = `<table id='instance_info_${instanceData['instance_id']}' class='unstriped'>
     <tr><td>Name:</td><td>${instanceData['name']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['name']}" title="Copy '${instanceData['name']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
     <tr><td>Hourly Price:</td><td>$${instanceData['price']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['price']}" title="Copy '${instanceData['price']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
     <tr><td>Instance ID:</td><td>${instanceData['instance_id']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['instance_id']}" title="Copy '${instanceData['instance_id']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
     <tr><td>AMI:</td><td>${instanceData['ami']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['ami']}" title="Copy '${instanceData['ami']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
     <tr><td>Profile:</td><td>${instanceData['profile']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['profile']}" title="Copy '${instanceData['profile']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
-  </table>`
+    `
+  if(instanceData['gpu_utilization']!=-1){
+    //gpu utilization is defined
+    infotable = infotable + `<tr><td>GPU Utilization:</td><td>${instanceData['gpu_utilization']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['gpu_utilization']}" title="Copy '${instanceData['gpu_utilization']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>`
+  }
+  infotable = infotable + `</table>`
+  return infotable
+  // return `<table id='instance_info_${instanceData['instance_id']}' class='unstriped'>
+  //   <tr><td>Name:</td><td>${instanceData['name']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['name']}" title="Copy '${instanceData['name']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
+  //   <tr><td>Hourly Price:</td><td>$${instanceData['price']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['price']}" title="Copy '${instanceData['price']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
+  //   <tr><td>Instance ID:</td><td>${instanceData['instance_id']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['instance_id']}" title="Copy '${instanceData['instance_id']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
+  //   <tr><td>AMI:</td><td>${instanceData['ami']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['ami']}" title="Copy '${instanceData['ami']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
+  //   <tr><td>Profile:</td><td>${instanceData['profile']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['profile']}" title="Copy '${instanceData['profile']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
+  //   <tr><td>GPU Utilization:</td><td>${instanceData['gpu_utilization']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['gpu_utilization']}" title="Copy '${instanceData['gpu_utilization']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>
+  // </table>`
 }
 
 function getControlPanel (server) {

--- a/nebula/static/js/app.js
+++ b/nebula/static/js/app.js
@@ -554,9 +554,9 @@ function getInstanceInfoTable (instanceData) {
     `
   if(instanceData['gpu_utilization']!=-1){
     //gpu utilization is defined
-    infotable_html = infotable + `<tr><td>GPU Utilization:</td><td>${instanceData['gpu_utilization']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['gpu_utilization']}" title="Copy '${instanceData['gpu_utilization']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>`
+    infotable_html += `<tr><td>GPU Utilization:</td><td>${instanceData['gpu_utilization']} <i data-tooltip data-disable-hover="false" data-clipboard-text="${instanceData['gpu_utilization']}" title="Copy '${instanceData['gpu_utilization']}' to clipboard." class="fa-clipboard fa copy"></i></td></tr>`
   }
-  infotable_html = infotable + `</table>`
+  infotable_html += `</table>`
   return infotable_html
 }
 


### PR DESCRIPTION
These changes allow for the display of the information contained in the GPU_Utilization tag of an instance, if it exists. If the instance does not have a GPU_Utilization tag, the information is not displayed. 

The json returned from the server_info endpoint will now include a new key 'gpu_utilization' in all cases. Note that -1 values of 'gpu_utilization' indicate that the instance does not have a GPU_Utilization tag (not a GPU-enabled instance?) 