### PR TITLE
Upgrade Dependencies and Tag Active Instances

### DIFF
--- a/nebula/nebula.py
+++ b/nebula/nebula.py
@@ -33,6 +33,7 @@ if not app.secret_key or app.secret_key is 'CHANGE_THIS_PASSWORD':
 @celery.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(65.0, aws.shutdown_expired_instances.s(), name='AWS Scheduled Shutdowns')
+    sender.add_periodic_task(301, aws.tag_active_instances.s(), name='AWS Active Instance Tags')
     sender.add_periodic_task(
         crontab(hour=4, minute=30),
         notifications.notify_users.s(),

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,21 +11,21 @@ Flask-User==1.0.2.2
 Flask-WTF==0.14.3
 
 # Automated tests
-pytest==6.0.2
-pytest-cov==2.10.1
+pytest==6.2.2
+pytest-cov==2.11.1
 
 # Libraries
 beaker==1.11.0
-boto3==1.15.3
+boto3==1.17.28
 blinker==1.4
-celery==4.4.7
+celery==5.0.5
 click==7.1.2
-ldap3==2.8.1
+ldap3==2.9
 psycopg2-binary==2.8.6
-pyotp==2.4.0
-pyyaml==5.3.1
-requests==2.24.0
-SQLAlchemy==1.3.19
+pyotp==2.6.0
+pyyaml==5.4.1
+requests==2.25.1
+SQLAlchemy==1.4.0
 sqlalchemy-migrate==0.13.0
 tzlocal==2.1
 


### PR DESCRIPTION
AWS doesn't have a way to identify when a machine was turned off. To get around this we're using celery to tag all active machines controlled by nebula with a timestamp of their most recent activity.