### PR TITLE
Autoterminate

### DIFF
--- a/nebula/nebula.py
+++ b/nebula/nebula.py
@@ -33,7 +33,8 @@ if not app.secret_key or app.secret_key is 'CHANGE_THIS_PASSWORD':
 @celery.on_after_finalize.connect
 def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(65.0, aws.shutdown_expired_instances.s(), name='AWS Scheduled Shutdowns')
-    sender.add_periodic_task(301, aws.tag_active_instances.s(), name='AWS Active Instance Tags')
+    sender.add_periodic_task(60*5, aws.tag_active_instances.s(), name='AWS Active Instance Tags')
+    sender.add_periodic_task(60*60, aws.terminate_expired_instances.s(), name='AWS Terminate Stopped Instances')
     sender.add_periodic_task(
         crontab(hour=4, minute=30),
         notifications.notify_users.s(),

--- a/nebula/services/aws.py
+++ b/nebula/services/aws.py
@@ -491,10 +491,12 @@ def terminate_expired_instances():
     curtimestamp = int(datetime.now(pytz.utc).timestamp())
     cutoff_timestamp = curtimestamp - (autoterminate*24*60*60)
 
-    instances = get_instance_list(state='stopped', terminated=False, tag_keys=['LastOnline'])
+    instances = get_instance_list(state='stopped', terminated=False, tag_keys=['LastOnline', 'CanTerminate'])
     for instance in instances:
         tags = get_tags_from_aws_object(instance)
         if 'LastOnline' not in tags or not tags['LastOnline'].isdigit():
+            continue
+        if 'CanTerminate' not in tags or tags['CanTerminate'] != "true":
             continue
         last_online = int(tags['LastOnline'])
         if last_online < cutoff_timestamp:


### PR DESCRIPTION
Allow autotermination. Machines with the `TerminateAfter` tag will be terminated after they have been shut down for the configured number of days (the configuration being the tag value).